### PR TITLE
Fix :below in parse-sequence-arguments

### DIFF
--- a/src/iterate.lisp
+++ b/src/iterate.lisp
@@ -335,7 +335,7 @@
 
 (defun parse-sequence-arguments
     (from upfrom downfrom to downto above below by)
-  (let* ((start (or from upfrom downfrom))
+  (let* ((start (or from upfrom downfrom (when below 1)))
          (end (or to downto above below))
          (increment (or by 1))
          (down (or downfrom downto above))


### PR DESCRIPTION
It needs to return 1 for START